### PR TITLE
Add OpenAI-powered page translation Chrome extension

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,0 +1,42 @@
+let collectedNodes = [];
+
+function isVisible(node) {
+  if (node.nodeType !== Node.TEXT_NODE) return false;
+  const parent = node.parentElement;
+  if (!parent) return false;
+  const tag = parent.tagName;
+  if (["SCRIPT","STYLE","NOSCRIPT","TEXTAREA","INPUT","CODE","PRE"].includes(tag)) return false;
+  if (parent.isContentEditable) return false;
+  const style = window.getComputedStyle(parent);
+  if (!style || style.visibility === "hidden" || style.display === "none") return false;
+  if (parent.offsetParent === null && style.position !== "fixed") return false;
+  return node.nodeValue.trim().length > 0;
+}
+
+function getTextNodes() {
+  const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+  const nodes = [];
+  let current;
+  while ((current = walker.nextNode())) {
+    if (isVisible(current)) {
+      nodes.push(current);
+    }
+  }
+  return nodes;
+}
+
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  if (msg.type === 'collectText') {
+    collectedNodes = getTextNodes();
+    const texts = collectedNodes.map(n => n.nodeValue);
+    sendResponse({ texts });
+    return true;
+  } else if (msg.type === 'applyTranslations') {
+    const { translations } = msg;
+    if (translations && translations.length === collectedNodes.length) {
+      collectedNodes.forEach((node, i) => {
+        node.nodeValue = translations[i];
+      });
+    }
+  }
+});

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,19 @@
+{
+  "manifest_version": 3,
+  "name": "One Click Translator",
+  "version": "1.0",
+  "description": "Translate entire pages using OpenAI while preserving layout.",
+  "permissions": ["storage", "activeTab", "scripting"],
+  "host_permissions": ["https://api.openai.com/*"],
+  "action": {
+    "default_popup": "popup.html"
+  },
+  "options_page": "options.html",
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content.js"],
+      "run_at": "document_idle"
+    }
+  ]
+}

--- a/options.html
+++ b/options.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+</head>
+<body>
+  <h1>Options</h1>
+  <label>OpenAI API Key: <input type="password" id="apiKey" size="40" /></label><br />
+  <label>Default Model:
+    <select id="defaultModel"></select>
+  </label><br />
+  <button id="save">Save</button>
+  <div id="status"></div>
+  <script src="options.js"></script>
+</body>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,31 @@
+const models = [
+  'gpt-4o-mini',
+  'gpt-4o',
+  'gpt-3.5-turbo'
+];
+
+function restoreOptions() {
+  chrome.storage.sync.get(['apiKey', 'defaultModel'], (data) => {
+    document.getElementById('apiKey').value = data.apiKey || '';
+    const select = document.getElementById('defaultModel');
+    models.forEach(m => {
+      const opt = document.createElement('option');
+      opt.value = m;
+      opt.textContent = m;
+      select.appendChild(opt);
+    });
+    select.value = data.defaultModel || 'gpt-4o-mini';
+  });
+}
+
+document.getElementById('save').addEventListener('click', () => {
+  const apiKey = document.getElementById('apiKey').value.trim();
+  const defaultModel = document.getElementById('defaultModel').value;
+  chrome.storage.sync.set({ apiKey, defaultModel }, () => {
+    const status = document.getElementById('status');
+    status.textContent = 'Saved.';
+    setTimeout(() => status.textContent = '', 1000);
+  });
+});
+
+document.addEventListener('DOMContentLoaded', restoreOptions);

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <style>
+    body { font-family: sans-serif; margin: 10px; }
+    #status { margin-top: 10px; }
+  </style>
+</head>
+<body>
+  <label for="model">Model:</label>
+  <select id="model"></select>
+  <button id="translate">OK</button>
+  <div id="status"></div>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,70 @@
+const models = [
+  'gpt-4o-mini',
+  'gpt-4o',
+  'gpt-3.5-turbo'
+];
+
+function loadOptions() {
+  chrome.storage.sync.get(['defaultModel'], (data) => {
+    const modelSelect = document.getElementById('model');
+    models.forEach(m => {
+      const option = document.createElement('option');
+      option.value = m;
+      option.textContent = m;
+      modelSelect.appendChild(option);
+    });
+    modelSelect.value = data.defaultModel || 'gpt-4o-mini';
+  });
+}
+
+document.getElementById('translate').addEventListener('click', async () => {
+  const model = document.getElementById('model').value;
+  const targetLang = navigator.language || 'en';
+  const status = document.getElementById('status');
+  status.textContent = 'Collecting text...';
+
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  chrome.tabs.sendMessage(tab.id, { type: 'collectText' }, async (response) => {
+    if (!response || !response.texts.length) {
+      status.textContent = 'No text found.';
+      return;
+    }
+    const texts = response.texts;
+    chrome.storage.sync.get(['apiKey'], async ({ apiKey }) => {
+      if (!apiKey) {
+        status.textContent = 'Set API key in options.';
+        return;
+      }
+      status.textContent = 'Translating...';
+      const delimiter = '\n###\n';
+      const joined = texts.join(delimiter);
+      try {
+        const res = await fetch('https://api.openai.com/v1/chat/completions', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${apiKey}`
+          },
+          body: JSON.stringify({
+            model,
+            messages: [
+              { role: 'system', content: `You are a translation engine.` },
+              { role: 'user', content: `Translate the following text to ${targetLang}. Each segment is separated by ${delimiter.trim()}. Return only the translated segments separated by ${delimiter.trim()}.` },
+              { role: 'user', content: joined }
+            ]
+          })
+        });
+        const data = await res.json();
+        const content = data.choices[0].message.content;
+        const translations = content.split(delimiter);
+        chrome.tabs.sendMessage(tab.id, { type: 'applyTranslations', translations });
+        status.textContent = 'Done';
+      } catch (e) {
+        console.error(e);
+        status.textContent = 'Error translating.';
+      }
+    });
+  });
+});
+
+document.addEventListener('DOMContentLoaded', loadOptions);


### PR DESCRIPTION
## Summary
- Create manifest, popup, options, and content scripts for an OpenAI-based page translator.
- Popup allows selecting the model and triggers full-page translation in the browser's language.
- Options page stores the OpenAI API key and default model.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ddcd4194c8328a936a670d03db6b3