### PR TITLE
Add OpenAI-powered page translation Chrome extension

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,6 +1,6 @@
 let collectedNodes = [];
 
-function isVisible(node) {
+const isVisible = (node) => {
   if (node.nodeType !== Node.TEXT_NODE) return false;
   const parent = node.parentElement;
   if (!parent) return false;
@@ -11,9 +11,9 @@ function isVisible(node) {
   if (!style || style.visibility === "hidden" || style.display === "none") return false;
   if (parent.offsetParent === null && style.position !== "fixed") return false;
   return node.nodeValue.trim().length > 0;
-}
+};
 
-function getTextNodes() {
+const getTextNodes = () => {
   const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
   const nodes = [];
   let current;
@@ -23,7 +23,7 @@ function getTextNodes() {
     }
   }
   return nodes;
-}
+};
 
 chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   if (msg.type === 'collectText') {

--- a/options.js
+++ b/options.js
@@ -4,11 +4,11 @@ const models = [
   'gpt-3.5-turbo'
 ];
 
-function restoreOptions() {
+const restoreOptions = () => {
   chrome.storage.sync.get(['apiKey', 'defaultModel'], (data) => {
-    document.getElementById('apiKey').value = data.apiKey || '';
-    const select = document.getElementById('defaultModel');
-    models.forEach(m => {
+    document.querySelector('#apiKey').value = data.apiKey || '';
+    const select = document.querySelector('#defaultModel');
+    models.forEach((m) => {
       const opt = document.createElement('option');
       opt.value = m;
       opt.textContent = m;
@@ -16,13 +16,13 @@ function restoreOptions() {
     });
     select.value = data.defaultModel || 'gpt-4o-mini';
   });
-}
+};
 
-document.getElementById('save').addEventListener('click', () => {
-  const apiKey = document.getElementById('apiKey').value.trim();
-  const defaultModel = document.getElementById('defaultModel').value;
+document.querySelector('#save').addEventListener('click', () => {
+  const apiKey = document.querySelector('#apiKey').value.trim();
+  const defaultModel = document.querySelector('#defaultModel').value;
   chrome.storage.sync.set({ apiKey, defaultModel }, () => {
-    const status = document.getElementById('status');
+    const status = document.querySelector('#status');
     status.textContent = 'Saved.';
     setTimeout(() => status.textContent = '', 1000);
   });

--- a/popup.js
+++ b/popup.js
@@ -4,10 +4,10 @@ const models = [
   'gpt-3.5-turbo'
 ];
 
-function loadOptions() {
+const loadOptions = () => {
   chrome.storage.sync.get(['defaultModel'], (data) => {
-    const modelSelect = document.getElementById('model');
-    models.forEach(m => {
+    const modelSelect = document.querySelector('#model');
+    models.forEach((m) => {
       const option = document.createElement('option');
       option.value = m;
       option.textContent = m;
@@ -15,12 +15,12 @@ function loadOptions() {
     });
     modelSelect.value = data.defaultModel || 'gpt-4o-mini';
   });
-}
+};
 
-document.getElementById('translate').addEventListener('click', async () => {
-  const model = document.getElementById('model').value;
+document.querySelector('#translate').addEventListener('click', async () => {
+  const model = document.querySelector('#model').value;
   const targetLang = navigator.language || 'en';
-  const status = document.getElementById('status');
+  const status = document.querySelector('#status');
   status.textContent = 'Collecting text...';
 
   const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });


### PR DESCRIPTION
## Summary
- Create manifest, popup, options, and content scripts for an OpenAI-based page translator.
- Popup allows selecting the model and triggers full-page translation in the browser's language.
- Options page stores the OpenAI API key and default model.
- Refactor scripts to use arrow functions for modern JavaScript syntax.
- Replace `document.getElementById` with `document.querySelector` for DOM access.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ddcd4194c8328a936a670d03db6b3